### PR TITLE
Timestamps on orders/etc

### DIFF
--- a/init_db.sh
+++ b/init_db.sh
@@ -24,6 +24,7 @@ CREATE TABLE IF NOT EXISTS plans (
     territory INTEGER NOT NULL,
     tier INTEGER,
     quota INTEGER,
+    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (territory)
         REFERENCES territory (id)
 );
@@ -48,6 +49,7 @@ CREATE TABLE IF NOT EXISTS orders (
     stars INTEGER,
     accepted BOOLEAN DEFAULT FALSE,
     uuid TEXT NOT NULL UNIQUE,
+    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (territory)
         REFERENCES territory (id)
 );
@@ -62,6 +64,7 @@ CREATE TABLE IF NOT EXISTS offers (
     stars INTEGER NOT NULL,
     rank INTEGER NOT NULL DEFAULT 0,
     uuid TEXT NOT NULL UNIQUE,
+    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (territory)
         REFERENCES territory (id)
 );


### PR DESCRIPTION
Added timestamps to several tables: Orders, Offers, and Plans.  Just a change to the db schema, no python code changes; since they're set to nullable and default to CURRENT_TIMESTAMP, these'll be entirely for forensic purposes.